### PR TITLE
Skills create controller routes

### DIFF
--- a/db/controllers/skills.controller.js
+++ b/db/controllers/skills.controller.js
@@ -1,0 +1,72 @@
+const { seq } = require('../index.js');
+const { models } = require('../index');
+
+exports.getSkills = async (req, res) => {
+  var dbError
+  const skills = await models.skill.findAll()
+      .catch(err => dbError = err);
+
+  if (dbError) { return res.status(400).json({"error": dbError}); }
+
+  res.json(skills)
+};
+
+exports.getSkill = async (req, res) => {
+    const skill = await models.skill.findByPk(req.params.id);
+    if (skill === null) {
+        return res.sendStatus(404);
+    }
+    res.json(skill);
+};
+
+exports.addSkill = async (req, res) => {
+    const {
+        name,
+        description
+    } = req.body;
+
+    var dbError;
+    const result = await models.skill.create({
+        name,
+        description
+    }).catch(err => dbError = err);
+
+    if (dbError) { return res.status(400).json({"error": err}); }
+
+    res.json(result);
+};
+
+exports.editSkill = async (req, res) => {
+    const skill = await models.skill.findByPk(req.params.id);
+    if (skill === null) {
+        return res.sendStatus(404);
+    }
+
+    const {
+        name,
+        description
+    } = req.body;
+
+    var dbError;
+    skill.update({name: name, description: description})
+      .catch(err => dbError = err);
+
+    if (dbError) { return res.status(400).json({"error": dbError }); }
+
+    res.json(skill);
+};
+
+exports.removeSkill = async (req, res) => {
+    const skill = await models.skill.findByPk(req.params.id);
+    if (skill === null) {
+        return res.sendStatus(404);
+    }
+
+    try {
+        // Delete always returns [].
+        const result = await skill.destroy()
+        res.json({"status": `skill ${req.params.id} removed`});
+    } catch (err) {
+        res.status(400).json({"error": err});
+    }
+};

--- a/db/controllers/skills.controller.js
+++ b/db/controllers/skills.controller.js
@@ -1,4 +1,3 @@
-const { seq } = require('../index.js');
 const { models } = require('../index');
 
 exports.getSkills = async (req, res) => {
@@ -31,7 +30,7 @@ exports.addSkill = async (req, res) => {
         description
     }).catch(err => dbError = err);
 
-    if (dbError) { return res.status(400).json({"error": err}); }
+    if (dbError) { return res.status(400).json({"error": dbError}); }
 
     res.json(result);
 };

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -5,6 +5,8 @@ services:
   db:
     image: postgres
     restart: always
+    ports:
+      - "5432:5432"
     environment:
       POSTGRES_PASSWORD: secret_password
       POSTGRES_USER: admin

--- a/server.js
+++ b/server.js
@@ -1,13 +1,15 @@
 require('dotenv').config({ path: `./.env.${process.env.NODE_ENV}`});
 const express = require('express');
 const path = require('path');
-const { 
-  getVolunteers, 
-  getVolunteer, 
-  addVolunteer, 
+const {
+  getVolunteers,
+  getVolunteer,
+  addVolunteer,
   editVolunteer,
   removeVolunteer
 } = require('./db/controllers/volunteers');
+
+const skillsController = require('./db/controllers/skills.controller');
 
 const app = express();
 app.use(express.json());
@@ -31,7 +33,14 @@ app.post('/api/volunteer/:id', editVolunteer);
 
 /* Remove a volunteer */
 app.delete('/api/volunteer/:id', removeVolunteer);
-  
+
+/* Skills routes */
+app.get('/api/skills', skillsController.getSkills);
+app.get('/api/skills/:id', skillsController.getSkill);
+app.post('/api/skills', skillsController.addSkill)
+app.put('/api/skills/:id', skillsController.editSkill)
+app.delete('/api/skills/:id', skillsController.removeSkill)
+
 // The "catchall" handler: for any request that doesn't
 // match one above, send back React's index.html file.
 app.get('*', (req, res) => {


### PR DESCRIPTION
Hey Will. Please take a look when you can.

Couple things going on here. I'll admit I haven't written Express routes in a while, but the Sequelize try-catch syntax is really throwing me. It seems really verbose, too many lines for what it's doing. I tried something a bit different, see what you think. No hard feelings if you don't think it works. Ultimately, we should have one pattern for all of these routes, for simplicity and consistency. I hesitated on the "delete" route; it seems delete returns [] when it succeeds and that could be the way to handle errors. Not sure ...

Separately, my sense is we are returning JSON on all of these routes. So I'm doing that here. That may be something we change on the other routes, which are returning normal body content currently.

Also error status. We probably want to return status codes on some of these error cases. We don't expect the frontend to parse error strings, right?

Docker-compose: I goofed and forgot to expose ports. That could be a separate PR if you want. I just added here.