### PR TITLE
Adding access control for routes.

### DIFF
--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -13,6 +13,7 @@
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "no-unused-vars": "warn",
     "no-console": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "react/prop-types": ["off"],
   }
 }

--- a/client/.eslintrc
+++ b/client/.eslintrc
@@ -15,5 +15,6 @@
     "no-console": "off",
     "import/prefer-default-export": "off",
     "react/prop-types": ["off"],
+    "react/jsx-props-no-spreading": "off"
   }
 }

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -6,7 +6,7 @@ import Register from '../pages/Register';
 import Dashboard from '../pages/Dashboard';
 import PageNotFound from '../pages/PageNotFound';
 
-import { VolunteerProvider } from '../lib/VolunteerProvider'
+import { VolunteerProvider, LockedRoute } from '../lib/VolunteerProvider'
 
 
 function App() {
@@ -26,14 +26,14 @@ function App() {
       <VolunteerProvider>
         <Switch>
           <Route exact path="/">
-          {loggedIn ? <Redirect to="/register" /> : <Home userNotFound={userNotFound} />}
+          {loggedIn ? <Redirect to="/register" /> : <Home />}
           </Route>
           <Route path="/register">
             <Register />
           </Route>
-          <Route path="/dashboard">
+          <LockedRoute path="/dashboard">
             <Dashboard />
-          </Route>
+          </LockedRoute>
           <Route path="*">
             <PageNotFound />
           </Route>

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -11,7 +11,6 @@ import { VolunteerProvider, LockedRoute } from '../lib/VolunteerProvider'
 
 function App() {
   const [loggedIn, setLoggedIn] = useState(false);
-  const [userNotFound, setUserNotFound] = useState(false);
 
   return (
     <HelmetProvider>

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import { Switch, Route, Redirect } from 'react-router-dom';
 import { Helmet, HelmetProvider } from 'react-helmet-async';
 import Home from '../pages/Home';
@@ -6,32 +6,12 @@ import Register from '../pages/Register';
 import Dashboard from '../pages/Dashboard';
 import PageNotFound from '../pages/PageNotFound';
 
+import { VolunteerProvider } from '../lib/VolunteerProvider'
+
+
 function App() {
   const [loggedIn, setLoggedIn] = useState(false);
   const [userNotFound, setUserNotFound] = useState(false);
-
-  const findUser = (email) => {
-    fetch('/api/user/find', {
-      method: 'POST',
-      body: JSON.stringify({ email }),
-      headers: { 'Content-Type': 'application/json' }
-    })
-        .then((res) => {
-          if (res.status === 404) {
-            setUserNotFound(true);
-            throw new Error();
-          } else {
-            return res.json();
-          }
-        })
-        .then((json) => {
-          // the variable json contains the user's profile information
-          setLoggedIn(true);
-        })
-        .catch((err) => {
-          console.log(err);
-        });
-  }
 
   return (
     <HelmetProvider>
@@ -43,20 +23,22 @@ function App() {
           rel="stylesheet"
         />
       </Helmet>
-      <Switch>
-        <Route exact path="/">
-        {loggedIn ? <Redirect to="/register" /> : <Home userNotFound={userNotFound} findUser={findUser} />}
-        </Route>
-        <Route path="/register">
-          <Register />
-        </Route>
-        <Route path="/dashboard">
-          <Dashboard />
-        </Route>
-        <Route path="*">
-          <PageNotFound />
-        </Route>
-      </Switch>
+      <VolunteerProvider>
+        <Switch>
+          <Route exact path="/">
+          {loggedIn ? <Redirect to="/register" /> : <Home userNotFound={userNotFound} />}
+          </Route>
+          <Route path="/register">
+            <Register />
+          </Route>
+          <Route path="/dashboard">
+            <Dashboard />
+          </Route>
+          <Route path="*">
+            <PageNotFound />
+          </Route>
+        </Switch>
+      </VolunteerProvider>
     </HelmetProvider>
   );
 }

--- a/client/src/lib/VolunteerProvider.js
+++ b/client/src/lib/VolunteerProvider.js
@@ -1,0 +1,68 @@
+
+import React, { useState, createContext, useContext } from "react";
+
+const VolunteerContext = createContext(null);
+
+function VolunteerProvider({ children }) {
+  const [profile, setProfile] = useState({
+    isAuthenticated: false,
+    exists: null,
+    email: '',
+  });
+
+  const signIn = (volunteerEmail) => {
+
+    fetch('/api/user/find', {
+      method: 'POST',
+      body: JSON.stringify({ volunteerEmail }),
+      headers: {
+        'Content-Type': 'application/json',
+      }
+    })
+    .then((res) => {
+      if (res.status === 404) {
+
+        // Setting not exists on 404?
+        const currentProfile = profile;
+        currentProfile.exists = false;
+        setProfile(currentProfile);
+
+        throw new Error('API 404');
+
+      } else return res.json();
+    })
+    .then((json) => {
+      setProfile({
+        isAuthenticated: true,
+        email: volunteerEmail,
+        exists: true,
+      });
+    })
+    .catch((err) => {
+      console.log(err);
+
+      // For now, fake successful return of profile.
+      console.log('Faking successful signin for now, for development.');
+      setProfile({
+        isAuthenticated: true,
+        exists: true,
+        email: volunteerEmail,
+      });
+    });
+  };
+  
+  const value = { 
+    profile, 
+    setProfile,
+    signIn, 
+  };
+
+  return (
+    <VolunteerContext.Provider value={value}>
+        {children}
+    </VolunteerContext.Provider>
+  );
+}
+
+export { VolunteerProvider, VolunteerContext };
+

--- a/client/src/lib/VolunteerProvider.js
+++ b/client/src/lib/VolunteerProvider.js
@@ -14,6 +14,7 @@ function VolunteerProvider({ children }) {
       isAuthenticated: false,
       notRegistered: false,
       email: '',
+      registrationStep: 0,
     };
   }
   
@@ -42,26 +43,33 @@ function VolunteerProvider({ children }) {
     })
     .then((response) => {
 
-      const updatedProfile = {
-        isAuthenticated: true,
-        email: volunteerEmail,
-        notRegistered: !response.exists, 
-      };
-      setProfile(updatedProfile);
-
       if (response.exists) {  // User found.
         const slackProfile = {
-          ...profile,
+          isAuthenticated: true,
+          email: volunteerEmail,
+          notRegistered: false, 
           suid: response.suid,
           name: response.name,
           img:  response.img,
         };
-
+        
         setProfile(slackProfile);
+        // Use localstorage for the moment until we get Sessions figured out.
+        localStorage.setItem('volunteer', JSON.stringify(slackProfile));
+      } else {
+
+        const updatedProfile = {
+          isAuthenticated: false,
+          email: volunteerEmail,
+          notRegistered: true, 
+          registrationStep: 0,
+        };
+        setProfile({});
+        setProfile(updatedProfile); 
+        // Use localstorage for the moment until we get Sessions figured out.
+        localStorage.setItem('volunteer', JSON.stringify(updatedProfile));
       }
 
-      // Use localstorage for the moment until we get Sessions figured out.
-      localStorage.setItem('volunteer', JSON.stringify(profile));
     })
     .catch((err) => {
       console.log(err);
@@ -83,11 +91,13 @@ function VolunteerProvider({ children }) {
     });
   };
 
-  const signOut = () => {
+  const clearProfile = () => {
+    setProfile({});
     setProfile({
       isAuthenticated: false,
       notRegistered: false,
       email: '',
+      registrationStep: 0,
     });
     // Use localstorage for the moment until we get Sessions figured out.
     localStorage.removeItem('volunteer');
@@ -97,7 +107,7 @@ function VolunteerProvider({ children }) {
     profile, 
     setProfile,
     slackExists, 
-    signOut,
+    clearProfile,
   };
 
   return (

--- a/client/src/lib/VolunteerProvider.js
+++ b/client/src/lib/VolunteerProvider.js
@@ -21,15 +21,18 @@ function VolunteerProvider({ children }) {
   const [profile, setProfile] = useState(defaultProfile);
 
   const signIn = (volunteerEmail) => {
-    fetch('/api/volunteer/validate/slack', {
+    fetch(`http://localhost:5000/api/volunteer/validate/slack`, {
       method: 'POST',
-      body: JSON.stringify({ volunteerEmail }),
+      body: JSON.stringify({ 
+        email: volunteerEmail 
+      }),
       headers: {
         'Content-Type': 'application/json',
       }
     })
     .then((data) => {
       if (data.status === 404) {
+        console.log(data);
         throw new Error('404: Route not found.');
       } else return data.json();
     })
@@ -44,15 +47,13 @@ function VolunteerProvider({ children }) {
 
       if (response.exists) {  // User found.
         const slackProfile = {
+          ...profile,
           suid: response.suid,
           name: response.name,
           img:  response.img,
         };
 
-        setProfile(profile => ({
-          ...profile,
-          ...slackProfile
-        }));
+        setProfile(slackProfile);
       }
 
       // Use localstorage for the moment until we get Sessions figured out.

--- a/client/src/lib/VolunteerProvider.js
+++ b/client/src/lib/VolunteerProvider.js
@@ -96,7 +96,7 @@ function VolunteerProvider({ children }) {
   const value = { 
     profile, 
     setProfile,
-    signIn, 
+    slackExists, 
     signOut,
   };
 

--- a/client/src/lib/VolunteerProvider.js
+++ b/client/src/lib/VolunteerProvider.js
@@ -66,11 +66,22 @@ function VolunteerProvider({ children }) {
 
     });
   };
+
+  const signOut = () => {
+    setProfile({
+      isAuthenticated: false,
+      notRegistered: false,
+      email: '',
+    });
+    // Use localstorage for the moment until we get Sessions figured out.
+    localStorage.removeItem('volunteer');
+  }
   
   const value = { 
     profile, 
     setProfile,
     signIn, 
+    signOut,
   };
 
   return (

--- a/client/src/lib/VolunteerProvider.js
+++ b/client/src/lib/VolunteerProvider.js
@@ -1,4 +1,3 @@
-
 import React, { useState, createContext, useContext } from "react";
 import { Route, Redirect } from 'react-router-dom';
 
@@ -20,8 +19,13 @@ function VolunteerProvider({ children }) {
   
   const [profile, setProfile] = useState(defaultProfile);
 
-  const signIn = (volunteerEmail) => {
-    fetch(`http://localhost:5000/api/volunteer/validate/slack`, {
+  /**
+   * Check if this email is signed up for the CFC Slack workspace.
+   * 
+   * @param {string} volunteerEmail 
+   */
+  const slackExists = (volunteerEmail) => {
+    fetch(`http://localhost:5000/api/volunteer/slack/exists`, {
       method: 'POST',
       body: JSON.stringify({ 
         email: volunteerEmail 

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,13 +1,9 @@
 import React, { useState, useEffect, useContext } from 'react';
-import PropTypes from 'prop-types';
+import { Redirect } from 'react-router-dom';
 import styled from 'styled-components';
 import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
-import Dialog from '@mui/material/Dialog';
-import DialogActions from '@mui/material/DialogActions';
-import DialogContent from '@mui/material/DialogContent';
-import DialogContentText from '@mui/material/DialogContentText';
-import TextField from '@mui/material/TextField';
+import { TextField, Dialog, DialogActions, DialogContent, DialogContentText, Alert, Grid } from '@mui/material';
 import { ReactComponent as WhiteSlackIcon } from '../assets/WhiteSlackIcon.svg';
 
 import { VolunteerContext } from '../lib/VolunteerProvider'
@@ -40,7 +36,6 @@ export default function Home() {
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState('');
 
-
   const Volunteer = useContext(VolunteerContext);
 
   const openModal = () => setModalOpen(true);
@@ -62,8 +57,14 @@ export default function Home() {
     }
   }, [Volunteer.profile.notRegistered]);
 
-  return (
-    <>
+  return (<>
+    {Volunteer.profile.isAuthenticated && <Redirect to="/register" />}
+    {Volunteer.profile.notRegistered &&
+      <Alert severity="warning">
+        Looks like you haven&apos;t joined our workspace. 
+        Please <a href="https://join.slack.com/t/apitest-jwd7276/shared_invite/zt-11cgm52ly-60DmFwe6BaXUN1wJnRa79g">join our workspace</a> before registering.
+      </Alert>
+    }
     <Dialog open={modalOpen}>
       <DialogContent>
         <DialogContentText>
@@ -79,11 +80,6 @@ export default function Home() {
             variant="standard"
             onChange={onInputChange}
           />
-        { Volunteer.profile.notRegistered &&
-          <DialogContentText>
-            Looks like you haven&apos;t joined our workspace. Please <a href="https://join.slack.com/t/apitest-jwd7276/shared_invite/zt-11cgm52ly-60DmFwe6BaXUN1wJnRa79g">click here</a> to join.
-          </DialogContentText>
-        }
         </DialogContent>
         <DialogActions>
           <Button onClick={closeModal}>Cancel</Button>
@@ -107,7 +103,6 @@ export default function Home() {
       </Button>
       <Button onClick={goToSlackLink} href="https://join.slack.com/t/apitest-jwd7276/shared_invite/zt-11cgm52ly-60DmFwe6BaXUN1wJnRa79g" size="small" variant="text">Not registered to our slack?</Button>
     </StyledSection>
-    </>
-  )
+  </>)
 }
 

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Button from '@mui/material/Button';
@@ -9,6 +9,8 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import TextField from '@mui/material/TextField';
 import { ReactComponent as WhiteSlackIcon } from '../assets/WhiteSlackIcon.svg';
+
+import { VolunteerContext } from '../lib/VolunteerProvider'
 
 const StyledSection = styled.section`
   width: 50%;
@@ -33,10 +35,13 @@ const StyledSection = styled.section`
   }
 `;
 
-export default function Home({ userNotFound, findUser }) {
+export default function Home({ userNotFound }) {
   const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState('');
+
+
+  const Volunteer = useContext(VolunteerContext);
 
   const openModal = () => setModalOpen(true);
   const closeModal = () => setModalOpen(false);
@@ -44,10 +49,6 @@ export default function Home({ userNotFound, findUser }) {
   const onInputChange = (e) => {
     setEmail(e.target.value);
   }
-
-  const searchForUser = () => {
-    findUser(email);
-  };
 
   const goToSlackLink = () => {
     window.location = 'https://join.slack.com/t/apitest-jwd7276/shared_invite/zt-11cgm52ly-60DmFwe6BaXUN1wJnRa79g';
@@ -66,7 +67,7 @@ export default function Home({ userNotFound, findUser }) {
     <Dialog open={modalOpen}>
       <DialogContent>
         <DialogContentText>
-          Let&apos;s see if you&apos;re in our workspace:
+          Let&apos;s see if you&apos;re in our workspace: 
         </DialogContentText>
         <TextField
             autoFocus
@@ -86,7 +87,7 @@ export default function Home({ userNotFound, findUser }) {
         </DialogContent>
         <DialogActions>
           <Button onClick={closeModal}>Cancel</Button>
-          <Button onClick={searchForUser}>{buttonText}</Button>
+          <Button onClick={() => Volunteer.signIn(email)}>{buttonText}</Button>
         </DialogActions>
     </Dialog>
     <StyledSection>
@@ -108,7 +109,6 @@ export default function Home({ userNotFound, findUser }) {
 }
 
 Home.propTypes = {
-  userNotFound: PropTypes.bool.isRequired,
-  findUser: PropTypes.func.isRequired,
+  userNotFound: PropTypes.bool.isRequired
 };
 

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -35,7 +35,7 @@ const StyledSection = styled.section`
   }
 `;
 
-export default function Home({ userNotFound }) {
+export default function Home() {
   const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [email, setEmail] = useState('');
@@ -57,10 +57,10 @@ export default function Home({ userNotFound }) {
   const buttonText = loading ? 'Searching...' : 'Submit';
 
   useEffect(() => {
-    if (userNotFound) {
+    if (Volunteer.profile.notRegistered) {
       setLoading(false);
     }
-  }, [userNotFound]);
+  }, [Volunteer.profile.notRegistered]);
 
   return (
     <>
@@ -79,7 +79,7 @@ export default function Home({ userNotFound }) {
             variant="standard"
             onChange={onInputChange}
           />
-        { userNotFound &&
+        { Volunteer.profile.notRegistered &&
           <DialogContentText>
             Looks like you haven&apos;t joined our workspace. Please <a href="https://join.slack.com/t/apitest-jwd7276/shared_invite/zt-11cgm52ly-60DmFwe6BaXUN1wJnRa79g">click here</a> to join.
           </DialogContentText>
@@ -87,7 +87,10 @@ export default function Home({ userNotFound }) {
         </DialogContent>
         <DialogActions>
           <Button onClick={closeModal}>Cancel</Button>
-          <Button onClick={() => Volunteer.signIn(email)}>{buttonText}</Button>
+          <Button onClick={() => {
+            Volunteer.signIn(email);
+            closeModal();
+          }}>{buttonText}</Button>
         </DialogActions>
     </Dialog>
     <StyledSection>
@@ -107,8 +110,4 @@ export default function Home({ userNotFound }) {
     </>
   )
 }
-
-Home.propTypes = {
-  userNotFound: PropTypes.bool.isRequired
-};
 

--- a/client/src/pages/Home.jsx
+++ b/client/src/pages/Home.jsx
@@ -88,7 +88,7 @@ export default function Home() {
         <DialogActions>
           <Button onClick={closeModal}>Cancel</Button>
           <Button onClick={() => {
-            Volunteer.signIn(email);
+            Volunteer.slackExists(email);
             closeModal();
           }}>{buttonText}</Button>
         </DialogActions>

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -32,17 +32,17 @@ export default function Register({ userDetails = null }) {
       }),
       headers: { 'Content-Type': 'application/json' }
     })
-        .then((res) => {
-          if (res.status === 404) {
-            throw new Error();
-          } else {
-            // Redirect??
-            return res.json();
-          }
-        })
-        .catch((err) => {
-          console.log(err);
-        });
+      .then((res) => {
+        if (res.status === 404) {
+          throw new Error();
+        } else {
+          // Redirect??
+          return res.json();
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
   }
 
   useEffect(() => {

--- a/db/controllers/volunteers.controller.js
+++ b/db/controllers/volunteers.controller.js
@@ -1,3 +1,6 @@
+require('dotenv').config({ 
+    path: `./.env.${process.env.NODE_ENV}`
+});
 const { models } = require('../index');
 const axios = require('axios');
 const Volunteer = models.volunteer;
@@ -176,7 +179,7 @@ const removeVolunteer = async (req, res) => {
  * @param {*} res - Request response object.
  */
 const validateVolunteerSlack = async (req, res) => {
-    const { email } = req.body;
+    const email = req.body?.email
 
     if (!email) {
         res.json({
@@ -204,10 +207,10 @@ const validateVolunteerSlack = async (req, res) => {
             }
             res.json(volunteer);
 
-        } else if (result.error) {
+        } else if (result.data.error) {
             res.json({
                 exists: false,
-                error: result.error,
+                error: result.data.error,
             });
 
         } else {
@@ -219,7 +222,7 @@ const validateVolunteerSlack = async (req, res) => {
         }
 
     } catch (err) {
-        res.status(500).json({
+        res.json({
             exists: false,
             error: err
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^0.24.0",
         "bcrypt": "^5.0.1",
+        "cors": "^2.8.5",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",
         "pg": "^8.7.1",
@@ -254,6 +255,18 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -1602,6 +1615,15 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "axios": "^0.24.0",
     "bcrypt": "^5.0.1",
+    "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
     "pg": "^8.7.1",

--- a/server.js
+++ b/server.js
@@ -1,5 +1,8 @@
-require('dotenv').config({ path: `./.env.${process.env.NODE_ENV}`});
+require('dotenv').config({ 
+  path: `./.env.${process.env.NODE_ENV}`
+});
 const express = require('express');
+const cors = require('cors');
 const axios = require('axios');
 const path = require('path');
 const volunteerController = require('./db/controllers/volunteers.controller');
@@ -9,6 +12,7 @@ const userController = require('./db/controllers/users.controller');
 const adminController = require('./db/controllers/admins.controller');
 
 const app = express();
+app.use(cors({ origin: true })); // todo: Limit open cors to client routes.
 
 app.use(express.urlencoded());
 app.use(express.json());

--- a/server.js
+++ b/server.js
@@ -28,6 +28,8 @@ app.post('/api/volunteer', volunteerController.addVolunteer);
 app.get('/api/volunteer/:id', volunteerController.getVolunteer);
 app.put('/api/volunteer/:id', volunteerController.editVolunteer);
 app.delete('/api/volunteer/:id', volunteerController.removeVolunteer);
+app.post('/api/volunteer/validate/slack', volunteerController.validateVolunteerSlack);
+
 
 /*========= SKILL ROUTES =========*/
 app.get('/api/skills', skillsController.getSkills);

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ app.post('/api/volunteer', volunteerController.addVolunteer);
 app.get('/api/volunteer/:id', volunteerController.getVolunteer);
 app.put('/api/volunteer/:id', volunteerController.editVolunteer);
 app.delete('/api/volunteer/:id', volunteerController.removeVolunteer);
-app.post('/api/volunteer/validate/slack', volunteerController.validateVolunteerSlack);
+app.post('/api/volunteer/slack/exists', volunteerController.validateVolunteerSlack);
 
 
 /*========= SKILL ROUTES =========*/


### PR DESCRIPTION
https://trello.com/c/4YGrkNDm/332-voma-restrict-all-pages-besides-landing-to-logged-in-users

- Added a VolunteerProvider to handle user login and state and restricting access to routes.
- Added a LockedRoute component to handle a locked route and used it to lock down "/dashboard" as an example.
- Using localstorage to persist login state across page refreshes until we pick a session solution.

A couple of notes:
1. When you "login" it attempts to hit the backend but is currently rigged to just log you in (on 404) for testing.
2. Once you log in, you're logged in. To clear your cache for testing (logout) you can run `locationStorage.removeItem("volunteer");` in your console. I added a signOut function on the VolunteerProvider but it needs a Log Out button added.
3. I undid a few things as their functionality was added into the VolunteerProvider. I nixed the userNotFound state variable and moved it into the Volunteer object for example.

